### PR TITLE
Hotfix/table prefix once

### DIFF
--- a/src/Sentinel/CmsTablePrefixed.php
+++ b/src/Sentinel/CmsTablePrefixed.php
@@ -11,18 +11,26 @@ trait CmsTablePrefixed
      */
     public function getTable()
     {
-        return $this->getCmsTablePrefix() . parent::getTable();
+        $tablePrefix = $this->getCmsTablePrefix();
+        $tableName   = parent::getTable();
+
+        if ($this->isPrefixed($tablePrefix, $tableName)) {
+            return $tableName;
+        }
+
+        return $tablePrefix . $tableName;
     }
 
     /**
-     * Override to force the database connection
-     *
-     * {@inheritdoc}
+     * @param string $tablePrefix
+     * @param string $tableName
+     * @return false|int
      */
-    public function getConnectionName()
+    protected function isPrefixed(string $tablePrefix, string $tableName)
     {
-        return $this->getCmsDatabaseConnection() ?: $this->connection;
+        return preg_match("/^{$tablePrefix}/", $tableName);
     }
+
 
     /**
      * @return string

--- a/src/Sentinel/CmsTablePrefixed.php
+++ b/src/Sentinel/CmsTablePrefixed.php
@@ -24,11 +24,11 @@ trait CmsTablePrefixed
     /**
      * @param string $tablePrefix
      * @param string $tableName
-     * @return false|int
+     * @return bool
      */
     protected function isPrefixed(string $tablePrefix, string $tableName)
     {
-        return preg_match("/^{$tablePrefix}/", $tableName);
+        return (bool) preg_match("/^{$tablePrefix}/", $tableName);
     }
 
 


### PR DESCRIPTION
Prevents table names from being prefixed more than once

Encountered errors due to table names with 2 or 3 prefixes, like `cms_cms_cms_<table>` where `cms_` is the prefix. Errors occured on authenticating CMS users after login, and creating users with `cms:user:create`. The error might also occur in other model-touching code.